### PR TITLE
feat: CLIN-1624 - load config user

### DIFF
--- a/config/config-user.go
+++ b/config/config-user.go
@@ -1,0 +1,33 @@
+package config
+
+import (
+	"fmt"
+
+	"github.com/magiconair/properties"
+)
+
+const ConfigUserFile = ".ferload-client.properties"
+const ConfigUserPath = "${HOME}/" + ConfigUserFile
+
+type ConfigUser struct {
+	FerloadUrl       string `properties:"ferload-url,default="`
+	UserName         string `properties:"username,default="`
+	Token            string `properties:"token,default="`
+	KeycloakUrl      string `properties:"keycloak-url,default="`
+	KeycloakRealm    string `properties:"keycloak-realm,default="`
+	KeycloakClientId string `properties:"keycloak-client-id,default="`
+	KeycloakAudience string `properties:"keycloak-audience,default="`
+}
+
+func LoadDefaultConfigUser() *ConfigUser {
+	return LoadConfigUser(ConfigUserPath)
+}
+
+func LoadConfigUser(path string) *ConfigUser {
+	cfg := &ConfigUser{}
+	p := properties.MustLoadFiles([]string{path}, properties.UTF8, true)
+	if err := p.Decode(cfg); err != nil {
+		panic(fmt.Sprintf("Failed to read user configuration file: %s reason: %s", ConfigUserPath, err))
+	}
+	return cfg
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/Ferlab-Ste-Justine/ferload-client-cli-go
 
 go 1.19
+
+require github.com/magiconair/properties v1.8.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
+github.com/magiconair/properties v1.8.7/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=

--- a/main.go
+++ b/main.go
@@ -1,5 +1,12 @@
 package main
 
+import (
+	"fmt"
+
+	"github.com/Ferlab-Ste-Justine/ferload-client-cli-go/config"
+)
+
 func main() {
-	println("Hello world!")
+	cfg := config.LoadDefaultConfigUser()
+	fmt.Printf("%+v\n", cfg)
 }

--- a/tests/config-user_test.go
+++ b/tests/config-user_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/Ferlab-Ste-Justine/ferload-client-cli-go/config"
+)
+
+func getField(cfg *config.ConfigUser, field string) string {
+	r := reflect.ValueOf(cfg)
+	f := reflect.Indirect(r).FieldByName(field)
+	return f.String()
+}
+
+func assertField(t *testing.T, cfg *config.ConfigUser, field string) {
+	if getField(cfg, field) != "" {
+		t.Errorf("%s should be empty", field)
+	}
+}
+
+func createTempFile(prefix string) *os.File {
+	file, err := ioutil.TempFile(os.TempDir(), config.ConfigUserFile)
+	if err != nil {
+		panic(err)
+	}
+	return file
+}
+
+func TestNewConfigUser_FileDoesntExist(t *testing.T) {
+	cfg := config.LoadConfigUser("")
+	assertField(t, cfg, "FerloadUrl")
+	assertField(t, cfg, "UserName")
+	assertField(t, cfg, "Token")
+	assertField(t, cfg, "KeycloakUrl")
+	assertField(t, cfg, "KeycloakClientId")
+	assertField(t, cfg, "KeycloakRealm")
+	assertField(t, cfg, "KeycloakAudience")
+	t.Log("TestNewConfigUserEmpty OK")
+}
+
+func TestNewConfigUser_EmptyFile(t *testing.T) {
+
+	tempCfg := createTempFile(config.ConfigUserFile).Name()
+	t.Logf("Create a temp file: %s", tempCfg)
+	defer os.Remove(tempCfg)
+
+	cfg := config.LoadConfigUser(tempCfg)
+	assertField(t, cfg, "FerloadUrl")
+	assertField(t, cfg, "UserName")
+	assertField(t, cfg, "Token")
+	assertField(t, cfg, "KeycloakUrl")
+	assertField(t, cfg, "KeycloakClientId")
+	assertField(t, cfg, "KeycloakRealm")
+	assertField(t, cfg, "KeycloakAudience")
+	t.Log("TestNewConfigUserEmpty OK")
+}


### PR DESCRIPTION
Be able to load, modify, reset and save the user configuration

Retro-compatibility: we will use the same file, path and properties used by the Scala implementation.

- [x] Can load config and extract values
- [ ] Can modify config
- [ ] Can reset config
- [ ] Can save config

- [x] Unit tests
- [ ] Update README.md